### PR TITLE
Ruby versions < 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Install an old Ruby version < 2.4:
 
     $ brew install rbenv/tap/openssl@1.0
     $ ruby-install ruby 2.2.0 -- --with-openssl-dir=$(brew --prefix openssl@1.0)
+    $ gem install bundler -v '~>1'
 
 Install a Ruby without installing dependencies first:
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ Install the latest version of Ruby:
 
 Install a stable version of Ruby:
 
-    $ ruby-install ruby 2.3
+    $ ruby-install ruby 2.7
 
 Install a specific version of Ruby:
 
-    $ ruby-install ruby 2.2.4
+    $ ruby-install ruby 2.7.1
 
 Install a Ruby into a specific directory:
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ Install a Ruby with specific configuration:
 
     $ ruby-install ruby 2.4.0 -- --enable-shared --enable-dtrace CFLAGS="-O3"
 
+Install an old Ruby version < 2.4:
+
+    $ brew install rbenv/tap/openssl@1.0
+    $ ruby-install ruby 2.2.0 -- --with-openssl-dir=$(brew --prefix openssl@1.0)
+
 Install a Ruby without installing dependencies first:
 
     $ ruby-install --no-install-deps ruby 2.4.0


### PR DESCRIPTION
Document how to install old ruby versions, which depend on OpenSSL 1.0